### PR TITLE
update instagram library to account for more than just images and videos

### DIFF
--- a/src/SocialFeed.php
+++ b/src/SocialFeed.php
@@ -534,8 +534,7 @@ class InstagramService extends SocialFeedService {
         $media->video->image = $item->images->standard_resolution->url;
         $media->video->service = 'instagram';
         break;
-      case 'image':
-      case 'carousel':
+      default:
         $media->image = $item->images->standard_resolution->url;
         break;
     }

--- a/src/SocialFeed.php
+++ b/src/SocialFeed.php
@@ -535,6 +535,7 @@ class InstagramService extends SocialFeedService {
         $media->video->service = 'instagram';
         break;
       case 'image':
+      case 'carousel':
         $media->image = $item->images->standard_resolution->url;
         break;
     }


### PR DESCRIPTION
Currently the library can't handle Instagram carousel images. By just using `default:` instead of a separate case, you avoid instagram introducing some other format that isn't accounted for in the library. It looks like all Instagram posts contain the `images` key in the response, and it should be the default fallback.